### PR TITLE
Remove hard-coding of master as main branch in workflow

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -3,9 +3,11 @@
 return [
     'branch_prefix' => env('LGW_BRANCH_PREFIX', ''),
     'project_owner' => env('LGW_PROJECT_OWNER', ''),
-    'github_user'   => env('LGW_GITHUB_USER', ''),
-    'wip'           => env('LGW_WIP', 'WIP'),
-    'env'           => base_path('.env'),
+    'github_user' => env('LGW_GITHUB_USER', ''),
+    'use_draft_pr' => env('LGW_DRAFT_PR', true),
+    'wip' => env('LGW_WIP', 'WIP'),
+    'trunk' => env('LGW_TRUNK', 'trunk'),
+    'env' => base_path('.env'),
     'composer_json' => base_path('/composer.json'),
-    'repositories'  => [],
+    'repositories' => [],
 ];

--- a/src/Actions/SetBranchForIssue.php
+++ b/src/Actions/SetBranchForIssue.php
@@ -26,14 +26,18 @@ class SetBranchForIssue
         if (in_array($issue, $branches)) {
             $this->git->execute('git checkout '.$this->branch);
             $this->git->execute('git fetch');
-            $this->git->execute('git rebase origin/master');
+            $this->git->execute('git rebase origin/'.config('laravel-git-workflow.trunk'));
 
             return 'Checked Out Existing Branch '.$issue;
         }
         $this->git->execute('git checkout -b '.$this->branch);
         $this->git->execute('git commit --allow-empty -m "'.config('laravel-git-workflow.wip').'"');
         $this->git->execute('git push -u origin '.$this->branch);
-        $this->git->execute('gh pr create -t '.urlencode(Str::title(str_replace('_', ' ', $this->branch))).' -b "'.config('laravel-git-workflow.wip').'" -d');
+        $pr = 'gh pr create -t '.urlencode(Str::title(str_replace('_', ' ', $this->branch))).' -b "'.config('laravel-git-workflow.wip').'"';
+        if (config('laravel-git-workflow.use_draft_prs')) {
+            $pr .= ' -d';
+        }
+        $this->git->execute($pr);
 
         return 'Created Branches and Draft PR for '.$issue;
     }

--- a/src/Commands/CloseIssue.php
+++ b/src/Commands/CloseIssue.php
@@ -23,8 +23,8 @@ class CloseIssue extends Command
 
     public function handle()
     {
-        if ($this->branch === 'master') {
-            $this->error('You cannot request a code review on the master branch. Run `php artisan issue:start` to get on your feature branch.');
+        if ($this->branch === config('laravel-git-workflow.trunk')) {
+            $this->error('You cannot request a code review on the main branch. Run `php artisan issue:start` to get on your feature branch.');
 
             return 1;
         }
@@ -34,6 +34,8 @@ class CloseIssue extends Command
         $this->git->execute('git commit -m "Requesting+a+code+review+from+'.$this->owner.'" --allow-empty');
 
         $this->git->execute('git push');
+
+        $this->git->execute('gh pull ready ' . $this->branch);
 
         $this->info('You have requested a code review of '.$this->branch.' by '.$this->owner.'.');
     }

--- a/src/Commands/SetRepository.php
+++ b/src/Commands/SetRepository.php
@@ -30,7 +30,7 @@ class SetRepository extends Command
         }
 
         $new = $packages[$this->package];
-        $new['version'] ??= 'dev-master';
+        $new['version'] ??= '*';
 
         $composer = json_decode(File::get(config('laravel-git-workflow.composer_json')), true);
 
@@ -50,13 +50,13 @@ class SetRepository extends Command
 
         foreach ($composer['require'] ?? [] as $k => $v) {
             if (Str::contains($k, $this->package)) {
-                $composer['require'][$k] = $this->repo === 'path' ? 'dev-master' : $new['version'];
+                $composer['require'][$k] = $this->repo === 'path' ? '*' : $new['version'];
             }
         }
 
         foreach ($composer['require-dev'] ?? [] as $k => $v) {
             if (Str::contains($k, $this->package)) {
-                $composer['require-dev'][$k] = $this->repo === 'path' ? 'dev-master' : $new['version'];
+                $composer['require-dev'][$k] = $this->repo === 'path' ? '*' : $new['version'];
             }
         }
 

--- a/src/Commands/StartDay.php
+++ b/src/Commands/StartDay.php
@@ -8,6 +8,7 @@ use Grosv\LaravelGitWorkflow\Actions\ParseGitHubIssues;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
 class StartDay extends Command
@@ -51,12 +52,12 @@ class StartDay extends Command
 
         $this->info('✔️ GitHub CLI appears to be installed');
 
-        $this->git->execute('git checkout master');
+        $this->git->execute('git checkout '.config('laravel-git-workflow.trunk'));
 
-        $this->info('✔️ Checked out master');
+        $this->info('✔️ Checked out '.config('laravel-git-workflow.trunk'));
         $this->git->execute('git pull --rebase');
 
-        $this->info('✔️ Master is up to date');
+        $this->info('✔️ '.Str::title(config('laravel-git-workflow.trunk')).' is up to date');
 
         $issues = $this->git->execute('gh issue list')->getOutput();
         $open = $this->issues->execute($issues);

--- a/src/Commands/UpdateIssue.php
+++ b/src/Commands/UpdateIssue.php
@@ -26,14 +26,15 @@ class UpdateIssue extends Command
     {
         $this->message = $this->argument('message');
 
-        if ($this->branch === 'master') {
-            $this->error('You cannot commit directly to the master branch. Run `php artisan issue:start` to get to your feature branch.');
+
+        if ($this->branch === config('laravel-git-workflow.trunk')) {
+            $this->error('You cannot commit directly to the '.config('laravel-git-workflow.trunk').' branch. Run `php artisan issue:start` to get to your feature branch.');
 
             return 1;
         }
 
         if (strlen($this->message) < 1) {
-            $this->message = config('laravel-git-workflow.wip');
+            $this->message = $this->ask('Please enter a commit message:', config('laravel-git-workflow.wip'));
         }
 
         $this->git->execute('git add .');

--- a/tests/SetRepositoryCommandTest.php
+++ b/tests/SetRepositoryCommandTest.php
@@ -27,7 +27,7 @@ class SetRepositoryCommandTest extends TestCase
             ],
             'my-sad-package' => [
                 'path'    => '../../packages/edgrosvenor/my-sad-package',
-                'version' => 'dev-master',
+                'version' => '*',
             ],
         ]);
 
@@ -58,7 +58,7 @@ class SetRepositoryCommandTest extends TestCase
 
         $updated = json_decode(File::get(config('laravel-git-workflow.composer_json')), true);
 
-        $this->assertEquals('dev-master', $updated['require']['edgrosvenor/my-crazy-package']);
+        $this->assertEquals('*', $updated['require']['edgrosvenor/my-crazy-package']);
 
         $this->assertEquals(['type' => 'path', 'url' => '../../packages/edgrosvenor/my-crazy-package'], $updated['repositories'][2]);
 
@@ -74,7 +74,7 @@ class SetRepositoryCommandTest extends TestCase
 
         $updated = json_decode(File::get(config('laravel-git-workflow.composer_json')), true);
 
-        $this->assertEquals('dev-master', $updated['require']['edgrosvenor/my-crazy-package']);
+        $this->assertEquals('*', $updated['require']['edgrosvenor/my-crazy-package']);
 
         $this->assertEquals(['type' => 'path', 'url' => '../../packages/edgrosvenor/my-crazy-package'], $updated['repositories'][2]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,8 @@ abstract class TestCase extends BaseTestCase
 
         Config::set('laravel-git-workflow.env', __DIR__.'/.env');
 
+        Config::set('laravel-git-workflow.stub', 'main');
+
         $this->resetDotEnv();
     }
 

--- a/tests/UpdateIssueCommandTest.php
+++ b/tests/UpdateIssueCommandTest.php
@@ -38,15 +38,15 @@ class UpdateIssueCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_let_you_commit_directly_to_master()
+    public function it_will_not_let_you_commit_directly_to_trunk()
     {
         $this->mock(GetCurrentBranchName::class, function ($mock) {
             $mock->shouldReceive('execute')
-                ->andReturn('master');
+                ->andReturn(config('laravel-git-workflow.trunk'));
         });
 
         $this->artisan('commit', ['message' => 'WIP'])
-            ->expectsOutput('You cannot commit directly to the master branch. Run `php artisan issue:start` to get to your feature branch.')
+            ->expectsOutput('You cannot commit directly to the '.config('laravel-git-workflow.trunk').' branch. Run `php artisan issue:start` to get to your feature branch.')
             ->assertExitCode(1);
     }
 


### PR DESCRIPTION
This PR removes all hard-coded instances of the word master and replaces them with a configuration variable. This is the first step in allowing us to rename all of our main branches.